### PR TITLE
Added XDG_STATE_HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ present in the environment.
 | XDG_DATA_DIRS   | `/usr/local/share`<br/>`/usr/share` | `/Library/Application Support`  | `%APPDATA%\Roaming`<br/>`%PROGRAMDATA%` |
 | XDG_CONFIG_HOME | `~/.config`                         | `~/Library/Preferences`         | `%LOCALAPPDATA%`                        |
 | XDG_CONFIG_DIRS | `/etc/xdg`                          | `/Library/Preferences`          | `%PROGRAMDATA%`                         |
+| XDG_STATE_HOME  | `~/.local/state`                            | `~/Library/Application Support` | `%LOCALAPPDATA%`                        |
 | XDG_CACHE_HOME  | `~/.cache`                          | `~/Library/Caches`              | `%LOCALAPPDATA%\cache`                  |
 | XDG_RUNTIME_DIR | `/run/user/UID`                     | `~/Library/Application Support` | `%LOCALAPPDATA%`                        |
 
@@ -110,6 +111,7 @@ func main() {
 	log.Println("Data directories:", xdg.DataDirs)
 	log.Println("Home config directory:", xdg.ConfigHome)
 	log.Println("Config directories:", xdg.ConfigDirs)
+	log.Println("Home state directory:", xdg.StateHome)
 	log.Println("Cache directory:", xdg.CacheHome)
 	log.Println("Runtime directory:", xdg.RuntimeDir)
 

--- a/base_dirs.go
+++ b/base_dirs.go
@@ -10,6 +10,7 @@ const (
 	envConfigDirs = "XDG_CONFIG_DIRS"
 	envCacheHome  = "XDG_CACHE_HOME"
 	envRuntimeDir = "XDG_RUNTIME_DIR"
+	envStateHome  = "XDG_STATE_HOME"
 )
 
 type baseDirectories struct {
@@ -19,6 +20,7 @@ type baseDirectories struct {
 	config     []string
 	cacheHome  string
 	runtime    string
+	stateHome  string
 
 	// Non-standard directories.
 	fonts        []string
@@ -35,6 +37,10 @@ func (bd baseDirectories) configFile(relPath string) (string, error) {
 
 func (bd baseDirectories) cacheFile(relPath string) (string, error) {
 	return createPath(relPath, []string{bd.cacheHome})
+}
+
+func (bd baseDirectories) stateFile(relPath string) (string, error) {
+	return createPath(relPath, []string{bd.stateHome})
 }
 
 func (bd baseDirectories) runtimeFile(relPath string) (string, error) {
@@ -75,4 +81,8 @@ func (bd baseDirectories) searchCacheFile(relPath string) (string, error) {
 
 func (bd baseDirectories) searchRuntimeFile(relPath string) (string, error) {
 	return searchFile(relPath, []string{bd.runtime})
+}
+
+func (bd baseDirectories) searchStateFile(relPath string) (string, error) {
+	return searchFile(relPath, []string{bd.stateHome})
 }

--- a/paths_darwin.go
+++ b/paths_darwin.go
@@ -12,6 +12,7 @@ func initBaseDirs(home string) {
 	baseDirs.config = xdgPaths(envConfigDirs, "/Library/Preferences")
 	baseDirs.cacheHome = xdgPath(envCacheHome, filepath.Join(home, "Library", "Caches"))
 	baseDirs.runtime = xdgPath(envRuntimeDir, filepath.Join(home, "Library", "Application Support"))
+	baseDirs.stateHome = xdgPath(envStateHome, filepath.Join(home, "Library", "Application Support"))
 
 	// Initialize non-standard directories.
 	baseDirs.applications = []string{

--- a/paths_darwin_test.go
+++ b/paths_darwin_test.go
@@ -19,6 +19,11 @@ func TestDefaultBaseDirs(t *testing.T) {
 			actual:   &xdg.DataHome,
 		},
 		&envSample{
+			name:     "XDG_STATE_HOME",
+			expected: filepath.Join(home, "Library", "Application Support"),
+			actual:   &xdg.StateHome,
+		},
+		&envSample{
 			name:     "XDG_DATA_DIRS",
 			expected: []string{"/Library/Application Support"},
 			actual:   &xdg.DataDirs,
@@ -72,6 +77,12 @@ func TestCustomBaseDirs(t *testing.T) {
 			value:    "~/Library/data",
 			expected: filepath.Join(home, "Library/data"),
 			actual:   &xdg.DataHome,
+		},
+		&envSample{
+			name:     "XDG_STATE_HOME",
+			value:    "~/Library/state",
+			expected: filepath.Join(home, "Library/state"),
+			actual:   &xdg.StateHome,
 		},
 		&envSample{
 			name:     "XDG_DATA_DIRS",

--- a/paths_unix.go
+++ b/paths_unix.go
@@ -16,6 +16,7 @@ func initBaseDirs(home string) {
 	baseDirs.config = xdgPaths(envConfigDirs, "/etc/xdg")
 	baseDirs.cacheHome = xdgPath(envCacheHome, filepath.Join(home, ".cache"))
 	baseDirs.runtime = xdgPath(envRuntimeDir, filepath.Join("/run/user", strconv.Itoa(os.Getuid())))
+	baseDirs.stateHome = xdgPath(envStateHome, filepath.Join(home, ".local", "state"))
 
 	// Initialize non-standard directories.
 	appDirs := []string{

--- a/paths_unix_test.go
+++ b/paths_unix_test.go
@@ -21,6 +21,11 @@ func TestDefaultBaseDirs(t *testing.T) {
 			actual:   &xdg.DataHome,
 		},
 		&envSample{
+			name:     "XDG_STATE_HOME",
+			expected: filepath.Join(home, ".local", "state"),
+			actual:   &xdg.StateHome,
+		},
+		&envSample{
 			name:     "XDG_DATA_DIRS",
 			expected: []string{"/usr/local/share", "/usr/share"},
 			actual:   &xdg.DataDirs,
@@ -76,6 +81,12 @@ func TestCustomBaseDirs(t *testing.T) {
 			value:    "~/.local/data",
 			expected: filepath.Join(home, ".local/data"),
 			actual:   &xdg.DataHome,
+		},
+		&envSample{
+			name:     "XDG_STATE_HOME",
+			value:    "~/.local/var",
+			expected: filepath.Join(home, ".local/var"),
+			actual:   &xdg.StateHome,
 		},
 		&envSample{
 			name:     "XDG_DATA_DIRS",

--- a/paths_windows.go
+++ b/paths_windows.go
@@ -41,6 +41,7 @@ func initBaseDirs(home string) {
 	baseDirs.config = xdgPaths(envConfigDirs, programDataDir)
 	baseDirs.cacheHome = xdgPath(envCacheHome, filepath.Join(localAppDataDir, "cache"))
 	baseDirs.runtime = xdgPath(envRuntimeDir, localAppDataDir)
+	baseDirs.stateHome = xdgPath(envStateHome, localAppDataDir)
 
 	// Initialize non-standard directories.
 	baseDirs.applications = []string{

--- a/paths_windows_test.go
+++ b/paths_windows_test.go
@@ -32,6 +32,11 @@ func TestDefaultBaseDirs(t *testing.T) {
 			actual:   &xdg.DataHome,
 		},
 		&envSample{
+			name:     "XDG_STATE_HOME",
+			expected: localAppData,
+			actual:   &xdg.StateHome,
+		},
+		&envSample{
 			name:     "XDG_DATA_DIRS",
 			expected: []string{roamingAppData, programData},
 			actual:   &xdg.DataDirs,
@@ -114,6 +119,12 @@ func TestCustomBaseDirs(t *testing.T) {
 			value:    filepath.Join(programData, "Cache"),
 			expected: filepath.Join(programData, "Cache"),
 			actual:   &xdg.CacheHome,
+		},
+		&envSample{
+			name:     "XDG_STATE_HOME",
+			value:    filepath.Join(programData, "Var"),
+			expected: filepath.Join(programData, "Var"),
+			actual:   &xdg.StateHome,
 		},
 		&envSample{
 			name:     "XDG_RUNTIME_DIR",

--- a/xdg.go
+++ b/xdg.go
@@ -51,6 +51,12 @@ var (
 	// relative to the ConfigHome directory, if possible.
 	ConfigDirs []string
 
+	// StateHome defines the base directory relative to which user-specific
+	// data (volatile) files should be stored. This directory is defined by the
+	// environment variable $XDG_STATE_HOME. If this variable is not set,
+	// a default equal to ~/.local/state should be used.
+	StateHome string
+
 	// CacheHome defines the base directory relative to which user-specific
 	// non-essential (cached) data should be written. This directory is
 	// defined by the environment variable $XDG_CACHE_HOME. If this variable
@@ -98,6 +104,7 @@ func Reload() {
 	RuntimeDir = baseDirs.runtime
 	FontDirs = baseDirs.fonts
 	ApplicationDirs = baseDirs.applications
+	StateHome = baseDirs.stateHome
 
 	// Initialize user directories.
 	initUserDirs(Home)
@@ -111,6 +118,16 @@ func Reload() {
 // attempted paths is returned.
 func DataFile(relPath string) (string, error) {
 	return baseDirs.dataFile(relPath)
+}
+
+// StateFile returns a suitable location for the specified data (volatile) file.
+// The relPath parameter must contain the name of the data file, and
+// optionally, a set of parent directories (e.g. appname/app.data).
+// If the specified directories do not exist, they will be created relative
+// to the base data directory. On failure, an error containing the
+// attempted paths is returned.
+func StateFile(relPath string) (string, error) {
+	return baseDirs.stateFile(relPath)
 }
 
 // ConfigFile returns a suitable location for the specified config file.
@@ -165,6 +182,14 @@ func SearchConfigFile(relPath string) (string, error) {
 // file cannot be found, an error specifying the searched path is returned.
 func SearchCacheFile(relPath string) (string, error) {
 	return baseDirs.searchCacheFile(relPath)
+}
+
+// SearchStateFile searches for the specified file in the state search path.
+// The relPath parameter must contain the name of the state file, and
+// optionally, a set of parent directories (e.g. appname/app.state). If the
+// file cannot be found, an error specifying the searched path is returned.
+func SearchStateFile(relPath string) (string, error) {
+	return baseDirs.searchStateFile(relPath)
 }
 
 // SearchRuntimeFile searches for the specified file in the runtime search path.

--- a/xdg_test.go
+++ b/xdg_test.go
@@ -71,6 +71,11 @@ func TestBaseDirFuncs(t *testing.T) {
 			pathFunc:   xdg.RuntimeFile,
 			searchFunc: xdg.SearchRuntimeFile,
 		},
+		{
+			relPaths:   []string{"app.db", "appname/app.db"},
+			pathFunc:   xdg.StateFile,
+			searchFunc: xdg.SearchStateFile,
+		},
 	}
 
 	for _, input := range inputs {


### PR DESCRIPTION
`XDG_STATE_HOME` is to enable people to split mutable and immutable data, such that immutable date stays in `XDG_DATA_HOME`, but applications can use `XDG_STATE_HOME` to store what normally would be stored in `/var/lib/app`

Better description of the problem https://github.com/ayekat/dotfiles/issues/30

Links
- https://wiki.debian.org/XDGBaseDirectorySpecification#Proposal:_STATE_directory
- https://lists.freedesktop.org/pipermail/xdg/2009-February/010191.html
- https://lists.freedesktop.org/pipermail/xdg/2012-December/012598.html
- https://lists.freedesktop.org/archives/xdg/2016-December/013803.html
- ActiveState/appdirs@ea0701d

… and more! (search the web for XDG_STATE_HOME)