### PR TITLE
Improve macOS config base directory defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@ present in the environment.
 
 #### XDG Base Directory
 
-|                 | Unix                                | macOS                           | Windows                                 |
-| :-------------- | :---------------------------------- | :------------------------------ | :-------------------------------------- |
-| XDG_DATA_HOME   | `~/.local/share`                    | `~/Library/Application Support` | `%LOCALAPPDATA%`                        |
-| XDG_DATA_DIRS   | `/usr/local/share`<br/>`/usr/share` | `/Library/Application Support`  | `%APPDATA%\Roaming`<br/>`%PROGRAMDATA%` |
-| XDG_CONFIG_HOME | `~/.config`                         | `~/Library/Preferences`         | `%LOCALAPPDATA%`                        |
-| XDG_CONFIG_DIRS | `/etc/xdg`                          | `/Library/Preferences`          | `%PROGRAMDATA%`                         |
-| XDG_CACHE_HOME  | `~/.cache`                          | `~/Library/Caches`              | `%LOCALAPPDATA%\cache`                  |
-| XDG_RUNTIME_DIR | `/run/user/UID`                     | `~/Library/Application Support` | `%LOCALAPPDATA%`                        |
+|                 | Unix                                | macOS                                                                                 | Windows                                 |
+| :-------------- | :---------------------------------- | :------------------------------------------------------------------------------------ | :-------------------------------------- |
+| XDG_DATA_HOME   | `~/.local/share`                    | `~/Library/Application Support`                                                       | `%LOCALAPPDATA%`                        |
+| XDG_DATA_DIRS   | `/usr/local/share`<br/>`/usr/share` | `/Library/Application Support`                                                        | `%APPDATA%\Roaming`<br/>`%PROGRAMDATA%` |
+| XDG_CONFIG_HOME | `~/.config`                         | `~/Library/Application Support`                                                       | `%LOCALAPPDATA%`                        |
+| XDG_CONFIG_DIRS | `/etc/xdg`                          | `~/Library/Preferences`<br/>`/Library/Application Support`<br/>`/Library/Preferences` | `%PROGRAMDATA%`                         |
+| XDG_CACHE_HOME  | `~/.cache`                          | `~/Library/Caches`                                                                    | `%LOCALAPPDATA%\cache`                  |
+| XDG_RUNTIME_DIR | `/run/user/UID`                     | `~/Library/Application Support`                                                       | `%LOCALAPPDATA%`                        |
 
 #### XDG user directories
 

--- a/paths_darwin.go
+++ b/paths_darwin.go
@@ -5,16 +5,23 @@ import (
 )
 
 func initBaseDirs(home string) {
+	homeAppSupport := filepath.Join(home, "Library", "Application Support")
+	rootAppSupport := "/Library/Application Support"
+
 	// Initialize base directories.
-	baseDirs.dataHome = xdgPath(envDataHome, filepath.Join(home, "Library", "Application Support"))
-	baseDirs.data = xdgPaths(envDataDirs, "/Library/Application Support")
-	baseDirs.configHome = xdgPath(envConfigHome, filepath.Join(home, "Library", "Preferences"))
-	baseDirs.config = xdgPaths(envConfigDirs, "/Library/Preferences")
+	baseDirs.dataHome = xdgPath(envDataHome, homeAppSupport)
+	baseDirs.data = xdgPaths(envDataDirs, rootAppSupport)
+	baseDirs.configHome = xdgPath(envConfigHome, homeAppSupport)
+	baseDirs.config = xdgPaths(envConfigDirs,
+		filepath.Join(home, "Library", "Preferences"),
+		rootAppSupport,
+		"/Library/Preferences",
+	)
 	baseDirs.cacheHome = xdgPath(envCacheHome, filepath.Join(home, "Library", "Caches"))
-	baseDirs.runtime = xdgPath(envRuntimeDir, filepath.Join(home, "Library", "Application Support"))
+	baseDirs.runtime = xdgPath(envRuntimeDir, homeAppSupport)
 
 	// Initialize non-standard directories.
-	baseDirs.stateHome = xdgPath(envStateHome, filepath.Join(home, "Library", "Application Support"))
+	baseDirs.stateHome = xdgPath(envStateHome, homeAppSupport)
 	baseDirs.applications = []string{
 		"/Applications",
 	}

--- a/paths_darwin_test.go
+++ b/paths_darwin_test.go
@@ -11,27 +11,33 @@ import (
 
 func TestDefaultBaseDirs(t *testing.T) {
 	home := xdg.Home
+	homeAppSupport := filepath.Join(home, "Library", "Application Support")
+	rootAppSupport := "/Library/Application Support"
 
 	testDirs(t,
 		&envSample{
 			name:     "XDG_DATA_HOME",
-			expected: filepath.Join(home, "Library", "Application Support"),
+			expected: homeAppSupport,
 			actual:   &xdg.DataHome,
 		},
 		&envSample{
 			name:     "XDG_DATA_DIRS",
-			expected: []string{"/Library/Application Support"},
+			expected: []string{rootAppSupport},
 			actual:   &xdg.DataDirs,
 		},
 		&envSample{
 			name:     "XDG_CONFIG_HOME",
-			expected: filepath.Join(home, "Library", "Preferences"),
+			expected: homeAppSupport,
 			actual:   &xdg.ConfigHome,
 		},
 		&envSample{
-			name:     "XDG_CONFIG_DIRS",
-			expected: []string{"/Library/Preferences"},
-			actual:   &xdg.ConfigDirs,
+			name: "XDG_CONFIG_DIRS",
+			expected: []string{
+				filepath.Join(home, "Library", "Preferences"),
+				rootAppSupport,
+				"/Library/Preferences",
+			},
+			actual: &xdg.ConfigDirs,
 		},
 		&envSample{
 			name:     "XDG_CACHE_HOME",
@@ -40,12 +46,12 @@ func TestDefaultBaseDirs(t *testing.T) {
 		},
 		&envSample{
 			name:     "XDG_RUNTIME_DIR",
-			expected: filepath.Join(home, "Library", "Application Support"),
+			expected: homeAppSupport,
 			actual:   &xdg.RuntimeDir,
 		},
 		&envSample{
 			name:     "XDG_STATE_HOME",
-			expected: filepath.Join(home, "Library", "Application Support"),
+			expected: homeAppSupport,
 			actual:   &xdg.StateHome,
 		},
 		&envSample{


### PR DESCRIPTION
Changed defaults for:

`XDG_CONFIG_HOME`: `~/Library/Preferences` to `~/Library/Application Support`.
`XDG_CONFIG_DIRS`: `/Library/Preferences` to `~/Library/Preferences:/Library/Application Support:/Library/Preferences`.

`~/Library/Preferences` was not a suitable place for application configuration files, as stated in the Apple Developer docs:

```
This directory contains app-specific preference files. You should not create files in this directory 
yourself. Instead, use the NSUserDefaults class or CFPreferences API to get and set preference
values for your app.
```

`~/Library/Application Support` seems like a more appropriate location:

```
Use this directory to store all app data files except those associated with the user’s documents.
For example, you might use this directory to store app-created data files, configuration files, templates,
or other fixed or modifiable resources that are managed by the app. An app might use this directory to 
store a modifiable  copy of resources contained initially in the app’s bundle. A game might use this 
directory to store new levels purchased by the user and downloaded from a server.

All content in this directory should be placed in a custom subdirectory whose name is that of your app’s
bundle identifier or your company.
```

[Reference](https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html#//apple_ref/doc/uid/TP40010672-CH2-SW1).