### PR TITLE
Fix link and socket detection in search methods

### DIFF
--- a/exist.go
+++ b/exist.go
@@ -1,0 +1,11 @@
+//go:build !windows
+// +build !windows
+
+package xdg
+
+import "os"
+
+func exists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil || os.IsExist(err)
+}

--- a/exist_windows.go
+++ b/exist_windows.go
@@ -1,0 +1,8 @@
+package xdg
+
+import "os"
+
+func exists(path string) bool {
+	_, err := os.Lstat(path)
+	return err == nil || os.IsExist(err)
+}

--- a/utils.go
+++ b/utils.go
@@ -33,11 +33,6 @@ func homeDir() string {
 	return ""
 }
 
-func exists(path string) bool {
-	_, err := os.Stat(path)
-	return err == nil || os.IsExist(err)
-}
-
 func expandPath(path, homeDir string) string {
 	if path == "" || homeDir == "" {
 		return path


### PR DESCRIPTION
Since we don't use the result and only want to know if the target exists, we can do even less processing of the target by using Lstat.
That is, don't resolve links, don't call file relevant stat methods on non-files like sockets, etc. Just check if they exist.
This specifically resolves an issue with `os.Stat` returning an error if the path is a Unix domain socket, on Windows (despite the path being valid and usable).

For example, this: https://github.com/golang/go/issues/33357#issuecomment-516847781
will return `CreateFile server.sock: The file cannot be accessed by the system.`
While changing to `Lstat` returns information on the target without error.
I'm experiencing this same issue with my own Go program which is creating and using valid Unix sockets, but they're not being found by `xdg.SearchRuntimeFile`, ` xdg.SearchConfigFile`, etc.

This specific issue with Stat may need to be fixed upstream, but using Lstat here may still make sense for symlinks, and other types.
*(Unless this goes against some xdg expectation, I'm not sure)