### PR TITLE
Add base support for XDG base user executable dir

### DIFF
--- a/base_dirs.go
+++ b/base_dirs.go
@@ -14,13 +14,14 @@ const (
 )
 
 type baseDirectories struct {
-	dataHome   string
-	data       []string
-	configHome string
-	config     []string
-	stateHome  string
-	cacheHome  string
-	runtime    string
+	dataHome       string
+	data           []string
+	configHome     string
+	config         []string
+	stateHome      string
+	cacheHome      string
+	executableHome string
+	runtime        string
 
 	// Non-standard directories.
 	fonts        []string
@@ -43,6 +44,10 @@ func (bd baseDirectories) cacheFile(relPath string) (string, error) {
 	return pathutil.Create(relPath, []string{bd.cacheHome})
 }
 
+func (bd baseDirectories) executableFile(relPath string) (string, error) {
+	return pathutil.Create(relPath, []string{bd.executableHome})
+}
+
 func (bd baseDirectories) runtimeFile(relPath string) (string, error) {
 	return pathutil.Create(relPath, []string{bd.runtime})
 }
@@ -61,6 +66,10 @@ func (bd baseDirectories) searchStateFile(relPath string) (string, error) {
 
 func (bd baseDirectories) searchCacheFile(relPath string) (string, error) {
 	return pathutil.Search(relPath, []string{bd.cacheHome})
+}
+
+func (bd baseDirectories) searchExecutableFile(relPath string) (string, error) {
+	return pathutil.Search(relPath, []string{bd.executableHome})
 }
 
 func (bd baseDirectories) searchRuntimeFile(relPath string) (string, error) {

--- a/paths_unix.go
+++ b/paths_unix.go
@@ -32,6 +32,7 @@ func initBaseDirs(home string) {
 	baseDirs.config = xdgPaths(envConfigDirs, "/etc/xdg")
 	baseDirs.stateHome = xdgPath(envStateHome, filepath.Join(home, ".local", "state"))
 	baseDirs.cacheHome = xdgPath(envCacheHome, filepath.Join(home, ".cache"))
+	baseDirs.executableHome = filepath.Join(home, ".local", "bin")
 	baseDirs.runtime = xdgPath(envRuntimeDir, filepath.Join("/run/user", strconv.Itoa(os.Getuid())))
 
 	// Initialize non-standard directories.

--- a/paths_unix_test.go
+++ b/paths_unix_test.go
@@ -115,6 +115,12 @@ func TestCustomBaseDirs(t *testing.T) {
 			actual:   &xdg.CacheHome,
 		},
 		&envSample{
+			name:     "__UNUSED__",
+			value:    "__UNUSED__",
+			expected: filepath.Join(home, ".local/bin"),
+			actual:   &xdg.ExecutableHome,
+		},
+		&envSample{
 			name:     "XDG_RUNTIME_DIR",
 			value:    "~/.local/runtime",
 			expected: filepath.Join(home, ".local/runtime"),

--- a/xdg.go
+++ b/xdg.go
@@ -55,6 +55,11 @@ var (
 	// is not set, a default equal to $HOME/.cache should be used.
 	CacheHome string
 
+	// ExecutableHome defines the base directory relative to which user-specific
+	// executable files should be written. This directory is not defined by
+	// any specific environment variable; it defaults to $HOME/.local/bin.
+	ExecutableHome string
+
 	// RuntimeDir defines the base directory relative to which user-specific
 	// non-essential runtime files and other file objects (such as sockets,
 	// named pipes, etc.) should be stored. This directory is defined by the
@@ -100,6 +105,7 @@ func Reload() {
 	ConfigDirs = baseDirs.config
 	StateHome = baseDirs.stateHome
 	CacheHome = baseDirs.cacheHome
+	ExecutableHome = baseDirs.executableHome
 	RuntimeDir = baseDirs.runtime
 
 	// Set non-standard directories.
@@ -149,6 +155,15 @@ func CacheFile(relPath string) (string, error) {
 	return baseDirs.cacheFile(relPath)
 }
 
+// ExecutableFile returns a suitable location for the specified user
+// specific executable file. The relPath parameter must contain the name of
+// the runtime file, without any parent directories. On failure, an error
+// containing the attempted path is returned.
+func ExecutableFile(relPath string) (string, error) {
+	// TODO: fail if relPath contains parent dirs
+	return baseDirs.executableFile(relPath)
+}
+
 // RuntimeFile returns a suitable location for the specified runtime file.
 // The relPath parameter must contain the name of the runtime file, and
 // optionally, a set of parent directories (e.g. appname/app.pid).
@@ -189,6 +204,15 @@ func SearchStateFile(relPath string) (string, error) {
 // file cannot be found, an error specifying the searched path is returned.
 func SearchCacheFile(relPath string) (string, error) {
 	return baseDirs.searchCacheFile(relPath)
+}
+
+// SearchExecutableFile searches for the specified file in the user specific
+// executable path. The relPath parameter must contain the name of the cache
+// file, without any parent directories. If the file cannot be found, an
+// error specifying the searched path is returned.
+func SearchExecutableFile(relPath string) (string, error) {
+	// TODO: fail if relPath contains parent dirs
+	return baseDirs.searchExecutableFile(relPath)
 }
 
 // SearchRuntimeFile searches for the specified file in the runtime search path.

--- a/xdg_test.go
+++ b/xdg_test.go
@@ -71,6 +71,11 @@ func TestBaseDirFuncs(t *testing.T) {
 			searchFunc: xdg.SearchCacheFile,
 		},
 		{
+			relPaths:   []string{"app"},
+			pathFunc:   xdg.ExecutableFile,
+			searchFunc: xdg.SearchExecutableFile,
+		},
+		{
 			relPaths:   []string{"app.pid", "appname/app.pid"},
 			pathFunc:   xdg.RuntimeFile,
 			searchFunc: xdg.SearchRuntimeFile,
@@ -174,6 +179,7 @@ func TestInvalidPaths(t *testing.T) {
 		"appname\000/app.yaml":   xdg.ConfigFile,
 		"appname/\000/app.state": xdg.StateFile,
 		"\000appname/app.cache":  xdg.CacheFile,
+		"appname/app":            xdg.ExecutableFile,
 		"\000/appname/app.pid":   xdg.RuntimeFile,
 	}
 


### PR DESCRIPTION
https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html

> There is a single base directory relative to which user-specific
> executable files may be written.

> User-specific executable files may be stored in $HOME/.local/bin.