### PR TITLE
Fix #29: Parse ~/.config/user-dirs.dirs file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.14
 require (
 	github.com/stretchr/testify v1.8.0
 	golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359
+	gopkg.in/ini.v1 v1.67.0
 )

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359 h1:2B5p2L5IfGiD7+b9BOoRMC6Dg
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
+gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/paths_unix.go
+++ b/paths_unix.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/adrg/xdg/internal/pathutil"
+	"gopkg.in/ini.v1"
 )
 
 func homeDir() string {
@@ -60,6 +61,21 @@ func initBaseDirs(home string) {
 }
 
 func initUserDirs(home string) {
+
+	// Load user dirs configuration if available
+	userDirFile := filepath.Join(Home, ".config/user-dirs.dirs")
+	if _, err := os.Stat(userDirFile); err == nil {
+		if cfg, err := ini.Load(userDirFile); err == nil {
+			for _, xdgFolder := range []string{envDesktopDir, envDownloadDir, envDocumentsDir, envMusicDir, envPicturesDir, envVideosDir, envTemplatesDir, envPublicShareDir} {
+				if os.Getenv(xdgFolder) == "" {
+					if key, err := cfg.Section("").GetKey(xdgFolder); err == nil {
+						os.Setenv(xdgFolder, key.Value())
+					}
+				}
+			}
+		}
+	}
+
 	UserDirs.Desktop = xdgPath(envDesktopDir, filepath.Join(home, "Desktop"))
 	UserDirs.Download = xdgPath(envDownloadDir, filepath.Join(home, "Downloads"))
 	UserDirs.Documents = xdgPath(envDocumentsDir, filepath.Join(home, "Documents"))


### PR DESCRIPTION
Read `~/.config/user-dirs.dirs` if exist, inject in env var if not already present

Test `TestDefaultUserDirs` will fail if localized file found.

Workaround without this merge:

```
func LoadlinuxXDG() {
	var (
		homeDir string
		err     error
	)

	if homeDir, err = os.UserHomeDir(); err != nil {
		fmt.Fprintln(os.Stderr, err)
		return
	}

	userDirFile := path.Join(homeDir, ".config/user-dirs.dirs")

	if _, err = os.Stat(userDirFile); err != nil {
		return
	}

	cfg, err := ini.Load(userDirFile)
	if err != nil {
		return
	}

	// Load xdg env
	for _, key := range cfg.Section("").Keys() {
		value := strings.Replace(key.Value(), "$HOME", homeDir, 1)
		os.Setenv(key.Name(), value)
	}

	xdg.Reload()
}
```