### PR TITLE
Update xdg.SearchRuntimeFile to also look in the temporary directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,9 @@ func main() {
 	// ConfigFile takes one parameter which must contain the name of the file,
 	// but it can also contain a set of parent directories. If the directories
 	// don't exist, they will be created relative to the base config directory.
+	// It is recommended for files to be saved inside an application directory
+	// relative to the base directory rather than directly inside the base
+	// directory (e.g. `appname/config.yaml` instead of `appname-config.yaml`).
 	configFilePath, err := xdg.ConfigFile("appname/config.yaml")
 	if err != nil {
 		log.Fatal(err)

--- a/base_dirs.go
+++ b/base_dirs.go
@@ -78,5 +78,5 @@ func (bd baseDirectories) searchCacheFile(relPath string) (string, error) {
 }
 
 func (bd baseDirectories) searchRuntimeFile(relPath string) (string, error) {
-	return pathutil.Search(relPath, []string{bd.runtime})
+	return pathutil.Search(relPath, pathutil.Unique([]string{bd.runtime, os.TempDir()}))
 }

--- a/doc.go
+++ b/doc.go
@@ -48,6 +48,9 @@ XDG Base Directory
 		// ConfigFile takes one parameter which must contain the name of the file,
 		// but it can also contain a set of parent directories. If the directories
 		// don't exist, they will be created relative to the base config directory.
+		// It is recommended for files to be saved inside an application directory
+		// relative to the base directory rather than directly inside the base
+		// directory (e.g. `appname/config.yaml` instead of `appname-config.yaml`).
 		configFilePath, err := xdg.ConfigFile("appname/config.yaml")
 		if err != nil {
 			log.Fatal(err)

--- a/xdg.go
+++ b/xdg.go
@@ -202,8 +202,11 @@ func SearchCacheFile(relPath string) (string, error) {
 
 // SearchRuntimeFile searches for the specified file in the runtime search path.
 // The relPath parameter must contain the name of the runtime file, and
-// optionally, a set of parent directories (e.g. appname/app.pid). If the
-// file cannot be found, an error specifying the searched path is returned.
+// optionally, a set of parent directories (e.g. appname/app.pid). The runtime
+// file is also searched in the operating system's temporary directory in order
+// to cover cases in which the runtime base directory does not exist or is not
+// accessible. If the file cannot be found, an error specifying the searched
+// path is returned.
 func SearchRuntimeFile(relPath string) (string, error) {
 	return baseDirs.searchRuntimeFile(relPath)
 }

--- a/xdg.go
+++ b/xdg.go
@@ -206,7 +206,7 @@ func SearchCacheFile(relPath string) (string, error) {
 // file is also searched in the operating system's temporary directory in order
 // to cover cases in which the runtime base directory does not exist or is not
 // accessible. If the file cannot be found, an error specifying the searched
-// path is returned.
+// paths is returned.
 func SearchRuntimeFile(relPath string) (string, error) {
 	return baseDirs.searchRuntimeFile(relPath)
 }


### PR DESCRIPTION
- Update `xdg.SearchRuntimeFile` to also look in the operating system's temporary directory for runtime files.
  This covers unlikely cases where runtime files cannot be written relative to the base runtime directory either because it does not exist or it is not accessible.
- Improve package testing.