### PR TITLE
Add XDG_PROJECTS_DIR support

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ as shown in the following tables.
 | <kbd><b>XDG_VIDEOS_DIR</b></kbd>                                 | <kbd>~/Videos</kbd>                                                         | <kbd>~/Movies</kbd>                                                           | <kbd>$home/videos</kbd>                                                       |
 | <kbd><b>XDG_TEMPLATES_DIR</b></kbd>                              | <kbd>~/Templates</kbd>                                                      | <kbd>~/Templates</kbd>                                                        | <kbd>$home/templates</kbd>                                                    |
 | <kbd><b>XDG_PUBLICSHARE_DIR</b></kbd>                            | <kbd>~/Public</kbd>                                                         | <kbd>~/Public</kbd>                                                           | <kbd>$home/public</kbd>                                                       |
+| <kbd><b>XDG_PROJECTS_DIR</b></kbd>                               | <kbd>~/Projects</kbd>                                                       | <kbd>~/Projects</kbd>                                                         | <kbd>$home/projects</kbd>                                                     |
 
 </details>
 
@@ -145,6 +146,7 @@ as shown in the following tables.
 | <kbd><b>XDG_VIDEOS_DIR</b></kbd>                                 | <kbd>Videos</kbd>                                                                           | <kbd>%USERPROFILE%\Videos</kbd>                                                    |
 | <kbd><b>XDG_TEMPLATES_DIR</b></kbd>                              | <kbd>Templates</kbd>                                                                        | <kbd>%APPDATA%\Microsoft\Windows\Templates</kbd>                                   |
 | <kbd><b>XDG_PUBLICSHARE_DIR</b></kbd>                            | <kbd>Public</kbd>                                                                           | <kbd>%PUBLIC%</kbd>                                                                |
+| <kbd><b>XDG_PROJECTS_DIR</b></kbd>                               | -                                                                                           | <kbd>%USERPROFILE%\Projects</kbd>                                                  |
 
 </details>
 
@@ -261,6 +263,7 @@ func main() {
 	log.Println("Videos directory:", xdg.UserDirs.Videos)
 	log.Println("Templates directory:", xdg.UserDirs.Templates)
 	log.Println("Public directory:", xdg.UserDirs.PublicShare)
+	log.Println("Projects directory:", xdg.UserDirs.Projects)
 }
 ```
 

--- a/doc.go
+++ b/doc.go
@@ -100,6 +100,7 @@ XDG user directories
 		log.Println("Videos directory:", xdg.UserDirs.Videos)
 		log.Println("Templates directory:", xdg.UserDirs.Templates)
 		log.Println("Public directory:", xdg.UserDirs.PublicShare)
+		log.Println("Projects directory:", xdg.UserDirs.Projects)
 	}
 */
 package xdg

--- a/internal/userdirs/config_unix.go
+++ b/internal/userdirs/config_unix.go
@@ -38,6 +38,7 @@ func ParseConfig(r io.Reader) (*Directories, error) {
 		EnvVideosDir:      &dirs.Videos,
 		EnvTemplatesDir:   &dirs.Templates,
 		EnvPublicShareDir: &dirs.PublicShare,
+		EnvProjectsDir:    &dirs.Projects,
 	}
 
 	scanner := bufio.NewScanner(r)

--- a/internal/userdirs/config_unix_test.go
+++ b/internal/userdirs/config_unix_test.go
@@ -56,6 +56,7 @@ func TestParseConfig(t *testing.T) {
 		XDG_MUSIC_DIR="$HOME/Music" # Music user directory
 		# XDG_PICTURES_DIR="$HOME/Pictures"
 		XDG_VIDEOS_DIR=""
+		XDG_PROJECTS_DIR="$HOME/Projects"
 
 		NON_XDG_DIR="ignore"
 		XDG_INVALID_DIR="ignore"
@@ -72,6 +73,7 @@ func TestParseConfig(t *testing.T) {
 	require.Equal(t, filepath.Join(home, "Music"), dirs.Music)
 	require.Equal(t, "", dirs.Pictures)
 	require.Equal(t, "", dirs.Videos)
+	require.Equal(t, filepath.Join(home, "Projects"), dirs.Projects)
 
 	// Test reader error.
 	f, err := os.CreateTemp("", "test_parse_config")

--- a/internal/userdirs/userdirs.go
+++ b/internal/userdirs/userdirs.go
@@ -10,6 +10,7 @@ const (
 	EnvVideosDir      = "XDG_VIDEOS_DIR"
 	EnvTemplatesDir   = "XDG_TEMPLATES_DIR"
 	EnvPublicShareDir = "XDG_PUBLICSHARE_DIR"
+	EnvProjectsDir    = "XDG_PROJECTS_DIR"
 )
 
 // Directories defines the locations of well known user directories.
@@ -37,4 +38,7 @@ type Directories struct {
 
 	// PublicShare defines a suitable location for user shared files.
 	PublicShare string
+
+	// Projects defines a suitable location for user projects.
+	Projects string
 }

--- a/paths_darwin.go
+++ b/paths_darwin.go
@@ -57,4 +57,5 @@ func initUserDirs(home string) {
 	UserDirs.Videos = pathutil.EnvPath(userdirs.EnvVideosDir, filepath.Join(home, "Movies"))
 	UserDirs.Templates = pathutil.EnvPath(userdirs.EnvTemplatesDir, filepath.Join(home, "Templates"))
 	UserDirs.PublicShare = pathutil.EnvPath(userdirs.EnvPublicShareDir, filepath.Join(home, "Public"))
+	UserDirs.Projects = pathutil.EnvPath(userdirs.EnvProjectsDir, filepath.Join(home, "Projects"))
 }

--- a/paths_darwin_test.go
+++ b/paths_darwin_test.go
@@ -190,6 +190,11 @@ func TestDefaultUserDirs(t *testing.T) {
 			expected: filepath.Join(home, "Public"),
 			actual:   &xdg.UserDirs.PublicShare,
 		},
+		&envSample{
+			name:     "XDG_PROJECTS_DIR",
+			expected: filepath.Join(home, "Projects"),
+			actual:   &xdg.UserDirs.Projects,
+		},
 	)
 }
 
@@ -244,6 +249,12 @@ func TestCustomUserDirs(t *testing.T) {
 			value:    "$HOME/Library/Public",
 			expected: filepath.Join(home, "Library/Public"),
 			actual:   &xdg.UserDirs.PublicShare,
+		},
+		&envSample{
+			name:     "XDG_PROJECTS_DIR",
+			value:    "$HOME/Library/Projects",
+			expected: filepath.Join(home, "Library/Projects"),
+			actual:   &xdg.UserDirs.Projects,
 		},
 	)
 }

--- a/paths_plan9.go
+++ b/paths_plan9.go
@@ -48,4 +48,5 @@ func initUserDirs(home string) {
 	UserDirs.Videos = pathutil.EnvPath(userdirs.EnvVideosDir, filepath.Join(home, "videos"))
 	UserDirs.Templates = pathutil.EnvPath(userdirs.EnvTemplatesDir, filepath.Join(home, "templates"))
 	UserDirs.PublicShare = pathutil.EnvPath(userdirs.EnvPublicShareDir, filepath.Join(home, "public"))
+	UserDirs.Projects = pathutil.EnvPath(userdirs.EnvProjectsDir, filepath.Join(home, "projects"))
 }

--- a/paths_plan9_test.go
+++ b/paths_plan9_test.go
@@ -173,6 +173,11 @@ func TestDefaultUserDirs(t *testing.T) {
 			expected: filepath.Join(home, "public"),
 			actual:   &xdg.UserDirs.PublicShare,
 		},
+		&envSample{
+			name:     "XDG_PROJECTS_DIR",
+			expected: filepath.Join(home, "projects"),
+			actual:   &xdg.UserDirs.Projects,
+		},
 	)
 }
 
@@ -227,6 +232,12 @@ func TestCustomUserDirs(t *testing.T) {
 			value:    filepath.Join(homeLib, "public"),
 			expected: filepath.Join(homeLib, "public"),
 			actual:   &xdg.UserDirs.PublicShare,
+		},
+		&envSample{
+			name:     "XDG_PROJECTS_DIR",
+			value:    filepath.Join(homeLib, "projects"),
+			expected: filepath.Join(homeLib, "projects"),
+			actual:   &xdg.UserDirs.Projects,
 		},
 	)
 }

--- a/paths_unix.go
+++ b/paths_unix.go
@@ -67,4 +67,5 @@ func initUserDirs(home, configHome string) {
 	UserDirs.Videos = pathutil.EnvPath(userdirs.EnvVideosDir, dirs.Videos, filepath.Join(home, "Videos"))
 	UserDirs.Templates = pathutil.EnvPath(userdirs.EnvTemplatesDir, dirs.Templates, filepath.Join(home, "Templates"))
 	UserDirs.PublicShare = pathutil.EnvPath(userdirs.EnvPublicShareDir, dirs.PublicShare, filepath.Join(home, "Public"))
+	UserDirs.Projects = pathutil.EnvPath(userdirs.EnvProjectsDir, dirs.Projects, filepath.Join(home, "Projects"))
 }

--- a/paths_unix_test.go
+++ b/paths_unix_test.go
@@ -184,6 +184,11 @@ func TestDefaultUserDirs(t *testing.T) {
 			expected: filepath.Join(home, "Public"),
 			actual:   &xdg.UserDirs.PublicShare,
 		},
+		&envSample{
+			name:     "XDG_PROJECTS_DIR",
+			expected: filepath.Join(home, "Projects"),
+			actual:   &xdg.UserDirs.Projects,
+		},
 	)
 }
 
@@ -238,6 +243,12 @@ func TestCustomUserDirs(t *testing.T) {
 			value:    "$HOME/.local/Public",
 			expected: filepath.Join(home, ".local/Public"),
 			actual:   &xdg.UserDirs.PublicShare,
+		},
+		&envSample{
+			name:     "XDG_PROJECTS_DIR",
+			value:    "$HOME/.local/Projects",
+			expected: filepath.Join(home, ".local/Projects"),
+			actual:   &xdg.UserDirs.Projects,
 		},
 	)
 }

--- a/paths_windows.go
+++ b/paths_windows.go
@@ -51,6 +51,7 @@ func initUserDirs(home string, kf *knownFolders) {
 	UserDirs.Videos = pathutil.EnvPath(userdirs.EnvVideosDir, kf.videos)
 	UserDirs.Templates = pathutil.EnvPath(userdirs.EnvTemplatesDir, kf.templates)
 	UserDirs.PublicShare = pathutil.EnvPath(userdirs.EnvPublicShareDir, kf.public)
+	UserDirs.Projects = pathutil.EnvPath(userdirs.EnvProjectsDir, kf.projects)
 }
 
 type knownFolders struct {
@@ -69,6 +70,7 @@ type knownFolders struct {
 	videos                 string
 	templates              string
 	public                 string
+	projects               string
 	fonts                  string
 	programs               string
 	commonPrograms         string
@@ -151,6 +153,11 @@ func initKnownFolders(home string) *knownFolders {
 		windows.FOLDERID_Public,
 		[]string{"PUBLIC"},
 		[]string{filepath.Join(kf.userProfiles, "Public")},
+	)
+	kf.projects = pathutil.KnownFolder(
+		nil,
+		nil,
+		[]string{filepath.Join(home, "Projects")},
 	)
 	kf.fonts = pathutil.KnownFolder(
 		windows.FOLDERID_Fonts,

--- a/paths_windows_test.go
+++ b/paths_windows_test.go
@@ -214,6 +214,11 @@ func TestDefaultUserDirs(t *testing.T) {
 			expected: filepath.Join(`C:\`, "Users", "Public"),
 			actual:   &xdg.UserDirs.PublicShare,
 		},
+		&envSample{
+			name:     "XDG_PROJECTS_DIR",
+			expected: filepath.Join(home, "Projects"),
+			actual:   &xdg.UserDirs.Projects,
+		},
 	)
 }
 
@@ -268,6 +273,12 @@ func TestCustomUserDirs(t *testing.T) {
 			value:    filepath.Join(home, "Files/Public"),
 			expected: filepath.Join(home, "Files/Public"),
 			actual:   &xdg.UserDirs.PublicShare,
+		},
+		&envSample{
+			name:     "XDG_PROJECTS_DIR",
+			value:    filepath.Join(home, "Files/Projects"),
+			expected: filepath.Join(home, "Files/Projects"),
+			actual:   &xdg.UserDirs.Projects,
 		},
 	)
 }


### PR DESCRIPTION
The recent [release 0.20](https://gitlab.freedesktop.org/xdg/xdg-user-dirs/-/commit/cd05b6d29da1abdb3cd253ef496ae7fd1593e4bb) of xdg-user-dirs introduced `XDG_PROJECTS_DIR` user directory. The [original proposal](https://gitlab.freedesktop.org/xdg/xdg-user-dirs/-/work_items/3) describes it as a directory for user software projects, like VCS directories, compiled binaries, etc. This PR adds support for this directory.

The default paths are similar to other user directories, such as `XDG_DOCUMENTS_DIR`. However, I couldn't find a Windows known folder with similar purpose. There are folders for installed programs, but from what I can tell there is no standard for "software projects". For now the Windows implementation just checks the environment variable and uses `%USERPROFILE%\Projects` as a fallback.

Let me know what you think.